### PR TITLE
feat(auth): Implement role-based and ownership authorization

### DIFF
--- a/src/main/java/com/bookapi/book_api/controller/BookController.java
+++ b/src/main/java/com/bookapi/book_api/controller/BookController.java
@@ -85,6 +85,7 @@ public class BookController implements BooksApi {
     }
 
     @Override
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<BookOutput> updateBook(UUID bookId, BookInput bookInput) {
         // Call the service function
         Book updatedBook = bookService.updateBook(bookId, bookInput);

--- a/src/main/java/com/bookapi/book_api/controller/BookController.java
+++ b/src/main/java/com/bookapi/book_api/controller/BookController.java
@@ -12,6 +12,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
@@ -32,6 +33,7 @@ public class BookController implements BooksApi {
 
 
     @Override
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<BookOutput> addBook(BookInput bookInput) {
         // Call the BookService method for adding a book
         Book createdBook = bookService.createBook(bookInput);

--- a/src/main/java/com/bookapi/book_api/controller/BookController.java
+++ b/src/main/java/com/bookapi/book_api/controller/BookController.java
@@ -50,6 +50,7 @@ public class BookController implements BooksApi {
     }
 
     @Override
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<Void> deleteBookById(UUID bookId) {
         // Call the service function
         Book deletedBook = bookService.deleteBook(bookId);

--- a/src/main/java/com/bookapi/book_api/controller/ReservationController.java
+++ b/src/main/java/com/bookapi/book_api/controller/ReservationController.java
@@ -12,6 +12,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -73,6 +74,7 @@ public class ReservationController implements ReservationsApi {
     }
 
     @Override
+    @PreAuthorize("hasRole('ADMIN') or @reservationSecurityService.isReservationOwner(authentication, #reservationId)")
     public ResponseEntity<ReservationOutput> getReservationById(UUID bookId, UUID reservationId) {
         // Call the service function
         Reservation userReservation = reservationService.findReservationById(bookId, reservationId);

--- a/src/main/java/com/bookapi/book_api/controller/ReservationController.java
+++ b/src/main/java/com/bookapi/book_api/controller/ReservationController.java
@@ -65,6 +65,7 @@ public class ReservationController implements ReservationsApi {
     }
 
     @Override
+    @PreAuthorize("hasRole('ADMIN') or @reservationSecurityService.isReservationOwner(authentication, #reservationId)")
     public ResponseEntity<ReservationOutput> cancelReservationById(UUID bookId, UUID reservationId) {
         // Call the service function
         Reservation cancelledReservation = reservationService.deleteReservationById(bookId, reservationId);

--- a/src/main/java/com/bookapi/book_api/service/ReservationSecurityService.java
+++ b/src/main/java/com/bookapi/book_api/service/ReservationSecurityService.java
@@ -1,0 +1,40 @@
+package com.bookapi.book_api.service;
+
+
+import com.bookapi.book_api.model.CustomOAuth2User;
+import com.bookapi.book_api.model.Reservation;
+import com.bookapi.book_api.repository.ReservationRepository;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Service("reservationSecurityService")
+public class ReservationSecurityService {
+
+    private final ReservationRepository reservationRepository;
+
+    public ReservationSecurityService(ReservationRepository reservationRepository) {
+        this.reservationRepository = reservationRepository;
+    }
+
+    public boolean isReservationOwner(Authentication authentication, UUID reservationId) {
+        // Get the database ID of the current logged in user
+        CustomOAuth2User currentUser = (CustomOAuth2User) authentication.getPrincipal();
+        UUID currentUserId = currentUser.getLocalUser().getId();
+
+        // Find the reservation in the database
+        Optional<Reservation> currentReservationOptional = reservationRepository.findById(reservationId);
+        // Check there is a Reservation in the retrieved Optional
+        if (currentReservationOptional.isEmpty()) {
+            return false;
+        }
+        // Retrieve the reservation from the Optional
+        Reservation currentReservation = currentReservationOptional.get();
+        UUID reservationOwner = currentReservation.getUserId();
+
+        // Check if the userId matches that of the reservation
+        return reservationOwner == currentUserId;
+    }
+}

--- a/src/main/java/com/bookapi/book_api/service/ReservationSecurityService.java
+++ b/src/main/java/com/bookapi/book_api/service/ReservationSecurityService.java
@@ -35,6 +35,6 @@ public class ReservationSecurityService {
         UUID reservationOwner = currentReservation.getUserId();
 
         // Check if the userId matches that of the reservation
-        return reservationOwner == currentUserId;
+        return reservationOwner.equals(currentUserId);
     }
 }

--- a/src/main/java/com/bookapi/book_api/service/ReservationService.java
+++ b/src/main/java/com/bookapi/book_api/service/ReservationService.java
@@ -56,4 +56,8 @@ public class ReservationService {
     public Page<Reservation> findReservationsForUser(UUID userId, Pageable pageable) {
         return reservationRepository.findByUserId(userId, pageable);
     }
+
+    public Page<Reservation> findAllReservations(Pageable pageable) {
+        return reservationRepository.findAll(pageable);
+    }
 }

--- a/src/test/java/com/bookapi/book_api/controller/BookControllerIntegrationTest.java
+++ b/src/test/java/com/bookapi/book_api/controller/BookControllerIntegrationTest.java
@@ -3,6 +3,7 @@ package com.bookapi.book_api.controller;
 
 import com.bookapi.book_api.dto.generated.BookInput;
 import com.bookapi.book_api.model.Book;
+import com.bookapi.book_api.model.CustomOAuth2User;
 import com.bookapi.book_api.model.User;
 import com.bookapi.book_api.repository.BookRepository;
 import com.bookapi.book_api.repository.UserRepository;
@@ -14,6 +15,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultMatcher;
@@ -23,6 +26,8 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -50,19 +55,24 @@ public class BookControllerIntegrationTest {
     }
 
     @Test
-    @WithMockUser
     @DisplayName(("POST /books should create a new book in the database and return 201"))
-    void postBook_whenBookIsValid_shouldCreateBookAndReturn201() throws Exception {
-        // GIVEN a DTO representing the request body
+    void postBook_whenBookIsValid_andUserIsAdmin_shouldCreateBookAndReturn201() throws Exception {
+        // GIVEN an admin user
+        User adminUser = new User("user@example.com", "Test User", "ROLE_ADMIN");
+        // AND that user is logged in
+        CustomOAuth2User principal = new CustomOAuth2User(mock(OidcUser.class), adminUser);
+        var auth = new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities());
+
+        // AND a DTO representing the request body
         BookInput bookInput = new BookInput();
         bookInput.setTitle("Fahrenheit 451");
         bookInput.setAuthor("Ray Bradbury");
         bookInput.setSynopsis("A dystopian novel about a future society that burns books.");
-        // Convert the DTO to JSON to represent an incoming request
         String bookInputJson = objectMapper.writeValueAsString(bookInput);
 
         // WHEN a POST request is made with the appropriate request body
         var resultActions = mockMvc.perform(post("/books")
+                        .with(authentication(auth))
                         .with(csrf())
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(bookInputJson));
@@ -72,6 +82,33 @@ public class BookControllerIntegrationTest {
                 .andExpect(jsonPath("$.id").isNotEmpty())
                 .andExpect(jsonPath("$.title", is("Fahrenheit 451")))
                 .andExpect(jsonPath("$.author", is("Ray Bradbury")));
+    }
+
+    @Test
+    @DisplayName("POST /books should return 403 Forbidden for non-admin user")
+    void postBook_whenUserIsNotAdmin_shouldReturn403() throws Exception {
+        // GIVEN a non-admin user
+        User regularUser = new User("user@example.com", "Test User", "ROLE_USER");
+        // AND that user is logged in
+        CustomOAuth2User principal = new CustomOAuth2User(mock(OidcUser.class), regularUser);
+        var auth = new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities());
+
+        // AND a DTO representing the request body
+        BookInput bookInput = new BookInput();
+        bookInput.setTitle("Fahrenheit 451");
+        bookInput.setAuthor("Ray Bradbury");
+        bookInput.setSynopsis("A dystopian novel about a future society that burns books.");
+        String bookInputJson = objectMapper.writeValueAsString(bookInput);
+
+        // WHEN a POST request is made with the appropriate request body
+        var resultActions = mockMvc.perform(post("/books")
+                .with(authentication(auth))
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(bookInputJson));
+
+        // THEN the response should be 403 Forbidden
+        resultActions.andExpect(status().isForbidden());
     }
 
     @Test


### PR DESCRIPTION
# Pull Request: Fine-Grained Authorization for Book and Reservation Endpoints

This Pull Request **hardens the security** of the API by implementing a **full suite of authorization rules** for all `Book` and `Reservation` endpoints. It moves beyond a simple "is authenticated" check to a **robust, fine-grained access control system**.

---

## Key Changes
- **Method-Level Security**: Enabled via `@EnableMethodSecurity`.
- **Declarative Rules**: Enforced using `@PreAuthorize` annotations.

---

## Authorization Rules Implemented

### **Book Resource**
| Endpoint                     | Access Rule                          |
|------------------------------|--------------------------------------|
| `POST /books`                | Restricted to `ROLE_ADMIN`.          |
| `PUT /books/{id}`            | Restricted to `ROLE_ADMIN`.          |
| `DELETE /books/{id}`         | Restricted to `ROLE_ADMIN`.          |

### **Reservation Resource**
| Endpoint                                     | Access Rule                                                                 |
|----------------------------------------------|-----------------------------------------------------------------------------|
| `GET /books/{...}/reservations/{id}`         | Restricted to **reservation owner** or `ROLE_ADMIN`.                      |
| `DELETE /books/{...}/reservations/{id}`      | Restricted to **reservation owner** or `ROLE_ADMIN`.                      |
| `GET /reservations`                          | **Role-Aware Behavior**:<br>- Regular users see **only their own reservations**.<br>- Admins can view **all reservations** or filter by `userId`. |

---

## Implementation Details
- **`ReservationSecurityService`**:
  - Introduced to encapsulate the custom **"is owner"** logic.
  - Called from the **SpEL expression** in `@PreAuthorize`.

- **`ReservationController`**:
  - Updated to differentiate between **admin and user roles** for `GET /reservations`.
  - Returns the correct dataset based on the user's role.

---

## Testing
- **Expanded Integration Tests**:
  - Added tests for **all authorization rules** in `BookController` and `ReservationController`.
  - Verifies that **non-privileged users** receive an `HTTP 403 Forbidden` status.

- **Refactored Existing Tests**:
  - Updated "happy path" tests to use principals with the **correct roles**.
  - Ensures the **entire test suite remains green**.

---
